### PR TITLE
Make the Makefile work everywhere

### DIFF
--- a/Array/Dot/Makefile
+++ b/Array/Dot/Makefile
@@ -1,3 +1,5 @@
+INC=$(shell python-config --includes) $(shell python -c "import numpy; print '-I' + numpy.get_include() + '/numpy'")
+
 all: dotSSE.so
 
 # remove compilation products
@@ -11,4 +13,4 @@ dotSSE.so:  dotSSE.o
 
 # ---- gcc C compile ------------------
 dotSSE.o:  dotSSE.c dotSSE.h
-	gcc -O3 --fast-math  -c dotSSE.c -I/usr/include/python2.7 -I/home/cyril.tasse/bin/lib/python2.7/site-packages/numpy/core/include/numpy  -I/home/tasse/bin/lib/python2.7/site-packages/numpy/core/include/numpy -I/home/tasse/bin/lib64/python2.7/site-packages/numpy-1.8.0-py2.7-linux-x86_64.egg/numpy/core/include/numpy -I/usr/lib/python2.7/dist-packages/numpy/core/include/numpy -I/home/cyril.tasse/bin/lib/python2.7/site-packages/numpy/core/include/numpy -I/home/tasse/bin/lib64/python2.7/site-packages/numpy-1.8.0-py2.7-linux-x86_64.egg/numpy/core/include/numpy -fPIC
+	gcc -O3 --fast-math  -c dotSSE.c $(INC) -fPIC

--- a/Gridder/Makefile
+++ b/Gridder/Makefile
@@ -1,3 +1,5 @@
+INC=$(shell python-config --includes) $(shell python -c "import numpy; print '-I' + numpy.get_include() + '/numpy'")
+
 # ---- Link --------------------------- 
 _pyGridder.so:  Gridder.o 
 	gcc -fopenmp -pthread -shared Gridder.o -o _pyGridder.so
@@ -6,7 +8,7 @@ _pyGridder.so:  Gridder.o
 Gridder.o:  Gridder.c Gridder.h
 #	gcc -O3 -msse -msse2 -msse2avx -msse3 -msse4.2 -mssse3 -march=corei7 -mtune=corei7 -c Gridder.c -I/usr/include/python2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include/numpy -fPIC	
 
-	gcc  -lgomp -fopenmp -pthread -Ofast --fast-math  -c Gridder.c -I/usr/include/python2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include/numpy -I/home/cyril.tasse/bin/lib/python2.7/site-packages/numpy/core/include/numpy -I/home/tasse/bin/lib64/python2.7/site-packages/numpy-1.8.0-py2.7-linux-x86_64.egg/numpy/core/include/numpy -fPIC	
+	gcc  -lgomp -fopenmp -pthread -Ofast --fast-math  -c Gridder.c $(INC) -fPIC	
 #	gcc  -lgomp -fopenmp -pthread -O3 -msse -msse2 -msse3 -msse4.2 -mssse3 -march=corei7 -mtune=corei7 --fast-math  -c Gridder.c -I/usr/include/python2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include/numpy -fPIC	
 
 #gcc -c Gridder.c -I/usr/include/python2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include/numpy -fPIC

--- a/Predict/Makefile
+++ b/Predict/Makefile
@@ -1,4 +1,4 @@
-
+INC=$(shell python-config --includes) $(shell python -c "import numpy; print '-I' + numpy.get_include() + '/numpy'")
 
 all: predict.so predict_np19.so
 
@@ -9,9 +9,7 @@ predict.so:  predict.o
 
 # ---- gcc C compile ------------------
 predict.o:  predict.c predict.h
-#	gcc -lgomp -fopenmp -pthread -Ofast --fast-math  -c predict.c -I/usr/include/python2.7 -fPIC
-	gcc -lgomp -fopenmp -pthread -Ofast --fast-math  -c predict.c -I/usr/include/python2.7 -I/home/cyril.tasse/bin/lib/python2.7/site-packages/numpy/core/include/numpy -I/home/tasse/bin/lib/python2.7/site-packages/numpy/core/include/numpy -I/home/tasse/bin/lib64/python2.7/site-packages/numpy-1.8.0-py2.7-linux-x86_64.egg/numpy/core/include/numpy -I/usr/lib/python2.7/dist-packages/numpy/core/include/numpy -I/home/cyril.tasse/bin/lib/python2.7/site-packages/numpy/core/include/numpy -I/home/tasse/bin/lib64/python2.7/site-packages/numpy-1.8.0-py2.7-linux-x86_64.egg/numpy/core/include/numpy -fPIC
-#	gcc -lgomp -fopenmp -pthread -Ofast --fast-math  -c predict.c -I/usr/include/python2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include/numpy -I/home/cyril.tasse/bin/lib/python2.7/site-packages/numpy/core/include/numpy -fPIC
+	gcc -lgomp -fopenmp -pthread -Ofast --fast-math  -c predict.c $(INC) -fPIC
 
 #	gcc -lgomp -fopenmp -pthread -Ofast -msse -msse2 -msse3 -msse4.2 -mssse3 -march=corei7 -mtune=corei7 --fast-math  -c predict.c -I/usr/include/python2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include/numpy -fPIC
 
@@ -21,4 +19,4 @@ predict_np19.so:  predict_np19.o
 	gcc -fopenmp -pthread -shared  predict_np19.o -o predict_np19.so
 
 predict_np19.o:  predict_np19.c predict_np19.h
-	gcc -lgomp -fopenmp -pthread -Ofast --fast-math  -c predict_np19.c -I/usr/include/python2.7 -I/home/tasse/bin/lib64/python2.7/site-packages/numpy-1.8.0-py2.7-linux-x86_64.egg/numpy/core/include/numpy -I/usr/lib/python2.7/dist-packages/numpy/core/include/numpy -I/home/cyril.tasse/bin/lib/python2.7/site-packages/numpy/core/include/numpy -I/home/tasse/bin/lib/python2.7/site-packages/numpy/core/include/numpy -I/usr/lib/python2.7/dist-packages/numpy/core/include/numpy -I/home/cyril.tasse/bin/lib/python2.7/site-packages/numpy/core/include/numpy -I/home/tasse/bin/lib64/python2.7/site-packages/numpy-1.8.0-py2.7-linux-x86_64.egg/numpy/core/include/numpy -fPIC
+	gcc -lgomp -fopenmp -pthread -Ofast --fast-math  -c predict_np19.c $(INC) -fPIC


### PR DESCRIPTION
Take the right includes independently of the system. It works as long as the Python headers and numpy are installed.